### PR TITLE
Fixed invalid index/typings name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "@fluffy-spoon/inverse",
     "version": "1.0.0",
     "description": "",
-    "main": "dist/src/Index.js",
-    "typings": "./dist/src/Index.d.ts",
+    "main": "dist/src/index.js",
+    "typings": "./dist/src/index.d.ts",
     "scripts": {
         "test": "tsc && ava",
         "build": "tsc"


### PR DESCRIPTION
The name as it stands does not seem to work fine on Linux for some reason.. :)